### PR TITLE
Upgrade to grails 3.2 & gradle 3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsVersion"
-        classpath 'com.bertramlabs.plugins:asset-pipeline-gradle:2.1.1'
+        classpath "com.bertramlabs.plugins:asset-pipeline-gradle:2.11.1"
     }
 }
 
@@ -17,7 +17,7 @@ plugins {
     id "com.jfrog.bintray" version "1.1"
 }
 
-version "2.0.0-SNAPSHOT"
+version "2.0.1-SNAPSHOT"
 group "org.grails.plugins"
 
 apply plugin: 'maven-publish'
@@ -59,14 +59,14 @@ dependencies {
     provided "org.springframework.boot:spring-boot-starter-tomcat"
 
     provided "org.grails:grails-web-boot"
-    provided "org.grails.plugins:hibernate"
+    provided "org.grails.plugins:hibernate5"
     provided "org.hibernate:hibernate-ehcache"
     provided "org.grails:grails-dependencies"
     provided 'javax.servlet:javax.servlet-api:3.1.0'
-
+    
     runtime "org.grails.plugins:asset-pipeline"
     testCompile "org.grails:grails-plugin-testing"
-
+    
     console "org.grails:grails-console"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-grailsVersion=3.0.3.BUILD-SNAPSHOT
-gradleWrapperVersion=2.3
+grailsVersion=3.2.0
+gradleWrapperVersion=3.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Feb 04 17:05:29 CST 2015
+#Sun Oct 02 08:50:15 EEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-all.zip

--- a/src/main/groovy/grails/plugins/rateable/RateableGrailsPlugin.groovy
+++ b/src/main/groovy/grails/plugins/rateable/RateableGrailsPlugin.groovy
@@ -20,7 +20,7 @@ package grails.plugins.rateable
  
  class RateableGrailsPlugin extends Plugin {
 
-    def grailsVersion = "3.0 > *"
+    def grailsVersion = "3.2 > *"
     def dependsOn = [:]
     def pluginExcludes = [
             "grails-app/views/error.gsp",


### PR DESCRIPTION
Hello ,

Due to following exception in my project . I made version upgrade on rateable plugin.

`Caused by: java.lang.ClassNotFoundException: org.grails.datastore.gorm.GormEntity$Trait$FieldHelper
    … 8 more`

I hope you will review and accept it.

Best Regards
